### PR TITLE
Bug fix: Dog should bark not meow

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,4 +5,4 @@ class Dog:
     self.age = age
 
   def speak(self):
-    print("Meow Meow")
+    print("Bark Bark")


### PR DESCRIPTION
Originally the "Dog" class has a method that would display "Meow Meow", while the expected message was "Bark Bark". This PR addresses that issue.